### PR TITLE
Move TripStatus spec description to valid location

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1857,7 +1857,6 @@ components:
           description: The ID of the trip for the arriving vehicle.
         tripStatus:
           $ref: '#/components/schemas/TripStatus'
-          description: Trip-specific status for the arriving transit vehicle.
         vehicleId:
           type: string
           description: ID of the transit vehicle serving this trip.
@@ -2163,6 +2162,7 @@ components:
 
     TripStatus:
       type: object
+      description: Trip-specific status for the arriving transit vehicle.
       properties:
         activeTripId:
           type: string


### PR DESCRIPTION
All other properties in a `$ref` object are ignored so it is invalid to have both `$ref` and description for the `tripStatus` of `ArrivalDepartureForStop`. This diff moves the description to the referenced object so it can be reused by other objects that reference the `TripStatus`. Reviewers can confirm the warning exists by using https://editor.swagger.io/ or some other OpenAPI spec validator tool.