### PR TITLE
feat: update OpenAPI schema to allow nullable fields for frequency and schedule

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1774,6 +1774,7 @@ components:
           description: Distance of the arriving transit vehicle from the stop, in meters.
         frequency:
           type: string
+          nullable: true
           description: Information about frequency-based scheduling, if applicable to the trip.
         historicalOccupancy:
           type: string
@@ -1792,12 +1793,14 @@ components:
           description: Indicates if real-time arrival info is available for this trip.
         predictedArrivalInterval:
           type: string
+          nullable: true
           description: Interval for predicted arrival time, if available.
         predictedArrivalTime:
           type: integer
           description: Predicted arrival time, in milliseconds since Unix epoch (zero if no real-time available).
         predictedDepartureInterval:
           type: string
+          nullable: true
           description: Interval for predicted departure time, if available.
         predictedDepartureTime:
           type: integer
@@ -1816,12 +1819,14 @@ components:
           description: Optional route short name that potentially overrides the route short name in the referenced route element.
         scheduledArrivalInterval:
           type: string
+          nullable: true
           description: Interval for scheduled arrival time.
         scheduledArrivalTime:
           type: integer
           description: Scheduled arrival time, in milliseconds since Unix epoch.
         scheduledDepartureInterval:
           type: string
+          nullable: true
           description: Interval for scheduled departure time.
         scheduledDepartureTime:
           type: integer
@@ -2181,6 +2186,7 @@ components:
           description: Distance, in meters, the transit vehicle has progressed along the active trip.
         frequency:
           type: string
+          nullable: true
           description: Information about frequency-based scheduling, if applicable to the trip.
         lastKnownDistanceAlongTrip:
           type: number
@@ -2307,6 +2313,7 @@ components:
 
     TripSchedule:
       type: object
+      nullable: true
       properties:
         frequency:
           type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API schema to allow certain fields to accept null values, including arrival/departure timing information and trip-related data, improving flexibility when handling unavailable information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->