### PR TITLE
feat: set default value of includeTrip to true in API schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -680,7 +680,8 @@ paths:
           required: false
           schema:
             type: boolean
-          description: Whether to include full trip elements in the references section. Defaults to false.
+            default: true
+          description: Whether to include full trip elements in the references section. Defaults to true.
         - name: includeSchedule
           in: query
           required: false


### PR DESCRIPTION
Fixes: #16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The trips-for-location API now includes full trip details in the references section by default.
* **Documentation**
  * Updated the API description to match the new default behavior for the trip-inclusion option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->